### PR TITLE
Temporary fix for register pages

### DIFF
--- a/modules/lib/util.xql
+++ b/modules/lib/util.xql
@@ -93,7 +93,8 @@ declare function tpu:get-template-config($request as map(*)) {
                 let $pval := array:fold-right(
                     [
                         request:get-parameter($param, ()),
-                        (: if (map:contains($request, 'parameters')) then $request?parameters($param) else (), :)
+                        (: Uncommented because of issue https://github.com/eeditiones/tei-publisher-app/issues/218 :)
+                        if (map:contains($request, 'parameters')) then $request?parameters($param) else (),
                         request:get-attribute($param),
                         session:get-attribute($config:session-prefix || "." || $param)
                     ], (),


### PR DESCRIPTION
The upgrade to TEI Publisher 9 caused issues on the person detail pages (see error message below). This is a temporary fix until https://github.com/eeditiones/tei-publisher-app/issues/218 is solved.

Error message:
```
{"code":"java:org.exist.xquery.XPathException","value":null,"module":null,"line":33,"column":24,"description":"exerr:ERROR Syntax error in Lucene query string: Cannot parse 'sender:': Encountered \"<EOF>\" at line 1, column 7.\nWas expecting one of:\n    <BAREOPER> ...\n    \"(\" ...\n    \"*\" ...\n    <QUOTED> ...\n    <TERM> ...\n    <PREFIXTERM> ...\n    <WILDTERM> ...\n    <REGEXPTERM> ...\n    \"[\" ...\n    \"{\" ...\n    <NUMBER> ...\n     [at line 33, column 24]\nIn function:\n\tapp:load-person(node(), map(*), xs:string)
```